### PR TITLE
Swap the order of the bold statements in the pledge

### DIFF
--- a/signatories/templates/index.html
+++ b/signatories/templates/index.html
@@ -19,10 +19,9 @@ freely available to readers as open access, without charging authors unfair
 prices.</p>
 
 <p><strong>For this reason, we will avoid serving as peer reviewers for venues
-  that do not make publicly available the research that we have reviewed.</strong>
+  that do not make publicly available the research that we review.</strong>
   Instead, we will give priority to open-access venues in
-  how we allocate our reviewing time and organizational efforts such as program
-  committee and board membership.
+  how we allocate our reviewing time and organizational efforts.
 </p>
 
 <p>Read the <a href="{% url 'faq' %}">FAQ</a> for more about open access and this pledge.</p>


### PR DESCRIPTION
Following feedback. I also think this makes sense: keeping a single strong sentence will help for readability, and the pledge is primarily about reviewing, so it makes sense to add programme committee membership as a logical consequence of the pledge, rather than being its core.